### PR TITLE
Return 0 from get_events when there are no events for the period.

### DIFF
--- a/zoneminder/monitor.py
+++ b/zoneminder/monitor.py
@@ -172,7 +172,7 @@ class Monitor:
         )
 
         try:
-            return event['results'][str(self._monitor_id)]
+            return event['results'].get(str(self._monitor_id), 0)
         except (TypeError, KeyError):
             return None
 


### PR DESCRIPTION
Fixes #23