### PR TITLE
Include new CaptureFPS property in availability calculation

### DIFF
--- a/zoneminder/zm.py
+++ b/zoneminder/zm.py
@@ -107,10 +107,10 @@ class ZoneMinder:
             return []
 
         monitors = []
-        for i in raw_monitors['monitors']:
-            raw_monitor = i['Monitor']
-            _LOGGER.info("Initializing camera %s", raw_monitor['Id'])
-            monitors.append(Monitor(self, raw_monitor))
+        for raw_result in raw_monitors['monitors']:
+            _LOGGER.debug("Initializing camera %s",
+                          raw_result['Monitor']['Id'])
+            monitors.append(Monitor(self, raw_result))
 
         return monitors
 


### PR DESCRIPTION
Starting in ZM 1.32.3 the monitor API also returns a Monitor_Status object per monitor
https://zoneminder.readthedocs.io/en/stable/api.html#return-a-list-of-all-monitors

The ZM front-end uses the CaptureFPS to determine if there is an error so I would like to do the same from HASS:
https://github.com/ZoneMinder/zoneminder/blob/bf3e783c42c6557c44cdb49bff594f1b1e6b5198/web/skins/classic/views/console.php#L245-L246

If the new property doesn't exist, the old calculation is used.