### PR TITLE
fix error spam in HA log after update to ZM 1.36+

### DIFF
--- a/zoneminder/monitor.py
+++ b/zoneminder/monitor.py
@@ -164,7 +164,7 @@ class Monitor:
         status = status_response.get("status")
         # ZoneMinder API returns an empty string to indicate that this monitor
         # cannot record right now
-        if status == "":
+        if status == "" or status == "Ok":
             return False
         return int(status) == STATE_ALARM
 


### PR DESCRIPTION
There's probably more that might need to be updated, however this fixes the immediate error spam in HA log after updating ZM to 1.36+ for the time being, while preserving the former functionality (as far as I can tell with what I am using the cameras in HA for)