### PR TITLE
Manage if monitors API return an error

### DIFF
--- a/zoneminder/monitor.py
+++ b/zoneminder/monitor.py
@@ -163,8 +163,8 @@ class Monitor:
 
         status = status_response.get("status")
         # ZoneMinder API returns an empty string to indicate that this monitor
-        # cannot record right now
-        if status == "":
+        # cannot record right now or false if there are any error
+        if status == "" or status == "false":
             return False
         return int(status) == STATE_ALARM
 


### PR DESCRIPTION
The ZM Monitors API could return and error, in this case the status field is "false" and is_recording() is only handling "false" or integer for status value.

Example for output when a monitor state return error:

`{'status': 'false', 'code': 255, 'error': ''}
`

I have found this issue with ZM v1.37.x, not tested in other ZM versions.