### PR TITLE
Monitor status might not be an int

### DIFF
--- a/zoneminder/monitor.py
+++ b/zoneminder/monitor.py
@@ -164,9 +164,10 @@ class Monitor:
         status = status_response.get("status")
         # ZoneMinder API returns an empty string to indicate that this monitor
         # cannot record right now
-        if status == "":
+        try:
+            return int(status) == STATE_ALARM
+        except ValueError:
             return False
-        return int(status) == STATE_ALARM
 
     @property
     def is_available(self) -> bool:


### PR DESCRIPTION
I have not observed these faults behavior myself

PR #49 and #50 have different string checks for what they saw.
This attempts to cover both and the faults logged in bug #51