### PR TITLE
Fixes monitor representation

### DIFF
--- a/zoneminder/monitor.py
+++ b/zoneminder/monitor.py
@@ -101,7 +101,7 @@ class Monitor:
 
     def __repr__(self) -> str:
         """Representation of a Monitor."""
-        return self._fmt.format(self.__class__.__name__, self.id, self.name)
+        return self._fmt.format(self.__class__.__name__, self.id, self.name, self.controllable)
 
     def __str__(self) -> str:
         """Representation of a Monitor."""


### PR DESCRIPTION
`Monitor.__repr__()` was missing a key in the formating that prevented the example of the `README.md` from this repostory from working.

At `Monitor.__init__()`:
`self._fmt = "{}(id={}, name={}, controllable={})"`

`self._fmt` is expecting four keys, but `Monitor.__repr__()` is only providing three:
```
def __repr__(self) -> str:
        """Representation of a Monitor."""
        return self._fmt.format(self.__class__.__name__, self.id, self.name)
```
I just added the missing one:
```
def __repr__(self) -> str:
        """Representation of a Monitor."""
        return self._fmt.format(self.__class__.__name__, self.id, self.name, self.controllable)
```