### PR TITLE
fix: filter soft-deleted ZoneMinder monitors

### DIFF
--- a/zoneminder/zm.py
+++ b/zoneminder/zm.py
@@ -223,6 +223,12 @@ class ZoneMinder:
 
         monitors = []
         for raw_result in raw_monitors["monitors"]:
+            # ZoneMinder >= 1.37/1.38 may retain deleted monitors
+            # as soft-deleted database records. Older releases do not
+            # expose the Deleted field.
+            if str(raw_result["Monitor"].get("Deleted", "0")).lower() in ("1", "true"):
+                continue
+
             _LOGGER.debug("Initializing camera %s", raw_result["Monitor"]["Id"])
             monitors.append(
                 Monitor(


### PR DESCRIPTION
## Filter soft-deleted monitors returned by ZoneMinder

ZoneMinder 1.37/1.38 introduced soft deletion for monitors. Deleted monitors may remain in the `Monitors` table and can still be returned by the REST API with the `Deleted` field set.

This causes clients using `zm-py.get_monitors()` to receive both the deleted monitor and a newly recreated monitor, even when they have the same name. For example:

| Id | Name | Deleted |
| -- | ----- | -------- |
| 2 | MONITOR-2 | 1 |
| 3 | MONITOR-2 | 0 |

Applications such as `ha-zoneminder` identify monitors by their ZoneMinder monitor ID, so both records are treated as separate cameras and duplicate entities appear in Home Assistant.

This change filters monitors whose `Deleted` field indicates that they have been soft-deleted.

The implementation deliberately uses a default value when reading the field:

```python
raw_result["Monitor"].get("Deleted", "0")
```

This keeps the change backward-compatible with ZoneMinder 1.36.x and other releases where the `Deleted` field is not present.

### Expected behavior

* ZoneMinder 1.36.x: unchanged behavior; monitors do not contain `Deleted` and are included normally.
* ZoneMinder 1.38.x: active monitors are returned normally; soft-deleted monitors are excluded.
* No explicit ZoneMinder version detection is required.

This makes `get_monitors()` represent the currently active monitor set rather than exposing ZoneMinder's retained soft-deleted records to downstream applications.
